### PR TITLE
Update build configuration to reflect KGP improvements

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -2,14 +2,8 @@ plugins {
     `kotlin-dsl`
 }
 
-repositories {
-    mavenCentral()
-    gradlePluginPortal()
-}
-
-val libs = extensions.getByType<VersionCatalogsExtension>().named("libs")
 dependencies {
-    implementation("org.jetbrains.dokka:dokka-gradle-plugin:1.9.10")
-    implementation("io.github.gradle-nexus:publish-plugin:1.3.0")
-    implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:${libs.findVersion("kotlin").get()}")
+    implementation(libs.dokka.plugin)
+    implementation(libs.nexus.plugin)
+    implementation(libs.kotlin.plugin)
 }

--- a/buildSrc/settings.gradle.kts
+++ b/buildSrc/settings.gradle.kts
@@ -1,4 +1,10 @@
 dependencyResolutionManagement {
+    @Suppress("UnstableApiUsage")
+    repositories {
+        mavenCentral()
+        gradlePluginPortal()
+    }
+
     versionCatalogs {
         create("libs") {
             from(files("../gradle/libs.versions.toml"))

--- a/buildSrc/src/main/kotlin/io/github/petertrr/ext/Project.ext.kt
+++ b/buildSrc/src/main/kotlin/io/github/petertrr/ext/Project.ext.kt
@@ -1,0 +1,12 @@
+package io.github.petertrr.ext
+
+import org.gradle.api.Project
+
+/**
+ * Returns a project property as a boolean (`"true" == true`, else `false`).
+ */
+fun Project.booleanProperty(name: String, default: Boolean = false): Boolean {
+    val property = findProperty(name) ?: return default
+    val propertyStr = property as? String ?: return default
+    return propertyStr.trim().lowercase() == "true"
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,13 +1,16 @@
 [versions]
 kotlin = "1.9.22"
-junit = "5.10.1"
 detekt = "1.23.5"
+dokka = "1.9.10"
+nexus = "1.3.0"
 
 [plugins]
-kotlin-multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
 detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
 
 [libraries]
-junit-jupiter-api = { module = "org.junit.jupiter:junit-jupiter-api", version.ref = "junit" }
-junit-jupiter-engine = { module = "org.junit.jupiter:junit-jupiter-engine", version.ref = "junit" }
-detekt-formatting = { module = "io.gitlab.arturbosch.detekt:detekt-formatting", version.ref = "detekt" }
+detekt-formatting = { group = "io.gitlab.arturbosch.detekt", name = "detekt-formatting", version.ref = "detekt" }
+
+# Gradle plugins
+kotlin-plugin = { group = "org.jetbrains.kotlin", name = "kotlin-gradle-plugin", version.ref = "kotlin" }
+dokka-plugin = { group = "org.jetbrains.dokka", name = "dokka-gradle-plugin", version.ref = "dokka" }
+nexus-plugin = { group = "io.github.gradle-nexus", name = "publish-plugin", version.ref = "nexus" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-kotlin = "1.9.22"
+kotlin = "1.9.23"
 detekt = "1.23.5"
 dokka = "1.9.10"
 nexus = "1.3.0"

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -13,6 +13,7 @@ plugins {
 rootProject.name = "kotlin-multiplatform-diff"
 
 dependencyResolutionManagement {
+    @Suppress("UnstableApiUsage")
     repositories {
         mavenCentral()
     }


### PR DESCRIPTION
I did a bit of a cleanup of the build scripts.  
Removed what wasn't necessary, centralized all dependencies in the root version catalog, and applied a more specific configuration to the JVM target.