### PR TITLE
Support WebAssembly targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # kotlin-multiplatform-diff
+
 ![Build and test](https://github.com/petertrr/kotlin-multiplatform-diff/workflows/Build%20and%20test/badge.svg)
 [![License](https://img.shields.io/github/license/petertrr/kotlin-multiplatform-diff)](https://github.com/petertrr/kotlin-multiplatform-diff/blob/main/LICENSE)
 [![codecov](https://codecov.io/gh/petertrr/kotlin-multiplatform-diff/branch/main/graph/badge.svg)](https://codecov.io/gh/petertrr/kotlin-multiplatform-diff)
@@ -7,21 +8,29 @@
 [![Maven Central](https://img.shields.io/maven-central/v/io.github.petertrr/kotlin-multiplatform-diff)](https://mvnrepository.com/artifact/io.github.petertrr)
 [![Awesome Kotlin Badge](https://kotlin.link/awesome-kotlin.svg)](https://github.com/KotlinBy/awesome-kotlin)
 
-This is a port of [java-diff-utils](https://github.com/java-diff-utils/java-diff-utils) to kotlin
-with multiplatform support. All credit for the implementation goes to original authors.
+This is a port of [java-diff-utils](https://github.com/java-diff-utils/java-diff-utils) to Kotlin with multiplatform support.  
+All credit for the implementation goes to original authors.
 
 ## Features
-All features from version 4.10 of the original library are present, except for:
-* Unified diff, which heavily uses file read/write and therefore needs a more complicated rewrite for kotlin-multiplatform
-* diff-utils-jgit, which uses JVM-only jgit library
+
+All features from version `4.10` of the original library are present, except for:
+
+- unified diff, which heavily uses file read/write and therefore needs a more complicated rewrite
+- diff-utils-jgit, which uses JVM-only jgit library
 
 Please refer to the original guides for more information.
 
-## Supported platforms
+## Supported Platforms
+
 Currently, artifacts for the following platforms are supported:
-* JVM
-* JS (both browser and Node.js)
-* WebAssembly (JS and WASI)
-* LinuxX64
-* MingwX64
-* MacosX64
+
+- JVM
+- JS (both browser and Node.js)
+- WebAssembly (JS and WASI)
+- Native
+
+The supported Native targets are:
+
+| Tier 1   | Tier 2   | Tier 3   |
+|:---------|:---------|:---------|
+| macosX64 | linuxX64 | mingwX64 |

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Please refer to the original guides for more information.
 Currently, artifacts for the following platforms are supported:
 * JVM
 * JS (both browser and Node.js)
+* WebAssembly (JS and WASI)
 * LinuxX64
 * MingwX64
 * MacosX64

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Currently, artifacts for the following platforms are supported:
 - WebAssembly (JS and WASI)
 - Native
 
-The supported Native targets are:
+The supported Native targets are (following the Kotlin/Native [target support guidelines](https://kotlinlang.org/docs/native-target-support.html)):
 
 | Tier 1   | Tier 2   | Tier 3   |
 |:---------|:---------|:---------|

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,6 +6,7 @@ import io.gitlab.arturbosch.detekt.Detekt
 import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
+import org.jetbrains.kotlin.gradle.targets.js.dsl.ExperimentalWasmDsl
 
 plugins {
     kotlin("multiplatform")
@@ -49,6 +50,21 @@ kotlin {
     js {
         browser()
         nodejs()
+    }
+
+    @OptIn(ExperimentalWasmDsl::class)
+    wasmJs {
+        browser()
+        nodejs()
+        applyBinaryen()
+    }
+
+    @OptIn(ExperimentalWasmDsl::class)
+    wasmWasi {
+        nodejs()
+
+        // Available since 2.0
+        // applyBinaryen()
     }
 
     linuxX64()

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-kotlin = "1.9.23"
+kotlin = "1.9.24"
 detekt = "1.23.5"
 dokka = "1.9.10"
 nexus = "1.3.0"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 kotlin = "1.9.24"
 detekt = "1.23.5"
-dokka = "1.9.10"
+dokka = "1.9.20"
 nexus = "1.3.0"
 
 [plugins]


### PR DESCRIPTION
Being WebAssembly is progressing at a fast pace, the more WASM-enabled libraries, the better.

Updating to 1.9.24 is required for using Node.js 22.