### PR TITLE
Simplify Gradle Reckon setup

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -7,7 +7,7 @@ pluginManagement {
 
 plugins {
     id("com.gradle.develocity") version ("3.19")
-    id("org.ajoberstar.reckon.settings") version ("0.18.2")
+    id("org.ajoberstar.reckon.settings") version ("0.19.1")
 }
 
 rootProject.name = "kotlin-multiplatform-diff"

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -19,12 +19,6 @@ dependencyResolutionManagement {
     }
 }
 
-extensions.configure<org.ajoberstar.reckon.gradle.ReckonExtension> {
-    setDefaultInferredScope("minor")
-    scopeFromProp()
-    stageFromProp("alpha", "rc", "final")  // version string will be based on last commit; when checking out a tag, that
-}
-
 develocity {
     buildScan {
         val isCI = System.getenv("CI").toBoolean()
@@ -38,4 +32,12 @@ develocity {
             onlyIf { isCI }
         }
     }
+}
+
+reckon {
+    setDefaultInferredScope("minor")
+    setScopeCalc(calcScopeFromProp())
+
+    stages("alpha", "rc", "final")
+    setStageCalc(calcStageFromProp())
 }


### PR DESCRIPTION
This also gets rid of deprecated APIs.

Follow up to #129.