### PR TITLE
Clean up the K2 build config

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -77,11 +77,36 @@ kotlin {
         nodejs()
     }
 
-    linuxX64()
-    linuxArm64()
-    mingwX64()
+    // Tier 1
     macosX64()
     macosArm64()
+    iosSimulatorArm64()
+    iosX64()
+    iosArm64()
+
+    // Tier 2
+    linuxX64()
+    linuxArm64()
+    watchosSimulatorArm64()
+    watchosX64()
+    watchosArm32()
+    watchosArm64()
+    tvosSimulatorArm64()
+    tvosX64()
+    tvosArm64()
+
+    // Tier 3
+    mingwX64()
+    androidNativeArm32()
+    androidNativeArm64()
+    androidNativeX86()
+    androidNativeX64()
+    watchosDeviceArm64()
+
+    // Deprecated.
+    // Should follow the same route as official Kotlin libraries
+    @Suppress("DEPRECATION")
+    linuxArm32Hfp()
 
     sourceSets {
         commonTest {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,9 +1,5 @@
-@file:OptIn(ExperimentalKotlinGradlePluginApi::class)
-
 import io.github.petertrr.configurePublishing
 import io.github.petertrr.ext.booleanProperty
-import io.gitlab.arturbosch.detekt.Detekt
-import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
 import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
@@ -26,8 +22,8 @@ kotlin {
     explicitApi()
 
     compilerOptions {
-        apiVersion = KotlinVersion.KOTLIN_1_9
-        languageVersion = KotlinVersion.KOTLIN_1_9
+        apiVersion = KotlinVersion.KOTLIN_2_1
+        languageVersion = KotlinVersion.KOTLIN_2_1
     }
 
     jvm {
@@ -35,7 +31,7 @@ kotlin {
             compileTaskProvider.configure {
                 compilerOptions {
                     // Minimum bytecode level is 52
-                    jvmTarget = JvmTarget.JVM_11
+                    jvmTarget = JvmTarget.JVM_1_8
 
                     // Output interfaces with default methods
                     freeCompilerArgs.addAll(
@@ -105,9 +101,7 @@ detekt {
 }
 
 tasks {
-    withType<Detekt> {
-        named("check") {
-            dependsOn(this@withType)
-        }
+    check {
+        dependsOn(detekt)
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,12 @@
-kotlin.code.style=official
-org.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
-org.gradle.caching=true
-# https://kotlinlang.org/docs/whatsnew19.html#preview-of-gradle-configuration-cache
-org.gradle.configuration-cache=false
-org.gradle.parallel=true
+#########################
+# Gradle settings
+#########################
+org.gradle.jvmargs = -Xmx2g -XX:MaxMetaspaceSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
+org.gradle.parallel = true
+org.gradle.caching = true
+org.gradle.configuration-cache = false
+
+#########################
+# Kotlin settings
+#########################
+kotlin.code.style = official

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,3 +10,6 @@ org.gradle.configuration-cache = false
 # Kotlin settings
 #########################
 kotlin.code.style = official
+
+# Kotlin/Native
+kotlin.native.enableKlibsCrossCompilation = true


### PR DESCRIPTION
- Set LV `KotlinVersion.KOTLIN_2_1`: this means we're effectively compiling with K2
- Set `JvmTarget.JVM_1_8`: no real reason to bump it to 11 imo, but in case let me know the rationale
- Enabled all the native targets by using `kotlin.native.enableKlibsCrossCompilation`

@petertrr you can also refactor the publishing step to publish everything in one go now.